### PR TITLE
Release action logout after execution and fix secret names

### DIFF
--- a/.github/workflows/buld-and-publish.yaml
+++ b/.github/workflows/buld-and-publish.yaml
@@ -107,6 +107,7 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_CLI_USERNAME }}
           password: ${{ secrets.DOCKERHUB_CLI_PASSWORD }}
+          logout: true
       - name: Push image
         run: make docker-push
   publish-image-redhat:
@@ -122,14 +123,15 @@ jobs:
       - name: Set env var VERSION
         run: echo "VERSION=${GITHUB_REF#refs/heads/release/}" >> $GITHUB_ENV
       - name: Set env var IMAGE
-        run: echo "IMAGE=scan.connect.redhat.com/${{ secrets.metrics-exporter_REDHAT_OSPID }}/metrics-exporter:${{ env.VERSION }}" >> $GITHUB_ENV
+        run: echo "IMAGE=scan.connect.redhat.com/${{ secrets.REDHAT_OSPID }}/metrics-exporter:${{ env.VERSION }}" >> $GITHUB_ENV
       - name: Build image
         run: make docker-build
       - name: Login to registry
         uses: docker/login-action@v1
         with:
           registry: scan.connect.redhat.com
-          username: ${{ secrets.metrics-exporter_REDHAT_USERNAME }}
-          password: ${{ secrets.metrics-exporter_REDHAT_TOKEN }}
+          username: ${{ secrets.REDHAT_USERNAME }}
+          password: ${{ secrets.REDHAT_TOKEN }}
+          logout: true
       - name: Push image
         run: docker docker-push


### PR DESCRIPTION
Fix the secrets name used on the action to push a new release image to redhat registry

Add logout option to both action that push images to registries