### PR TITLE
renamed storageos-metrics-exporter-svc to storageos-metrics-exporter

### DIFF
--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -43,7 +43,7 @@ metadata:
   labels:
     app: storageos
     service-discovery: storageos-metrics-exporter
-  name: storageos-metrics-exporter-svc
+  name: storageos-metrics-exporter
   namespace: storageos
 spec:
   clusterIP: None

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: storageos-metrics-exporter-svc
+  name: storageos-metrics-exporter
   labels:
     service-discovery: storageos-metrics-exporter
 spec:


### PR DESCRIPTION
https://ondat.atlassian.net/browse/CTRL-175

To make operator use it, let's bump the version here and the dependency in the operator repo.