### PR TITLE
Clean labels

### DIFF
--- a/manifests/bundle.yaml
+++ b/manifests/bundle.yaml
@@ -71,7 +71,6 @@ spec:
   selector:
     app: storageos
     app.kubernetes.io/component: metrics-exporter
-    category: metrics-exporter
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -91,7 +90,6 @@ spec:
       labels:
         app: storageos
         app.kubernetes.io/component: metrics-exporter
-        category: metrics-exporter
     spec:
       containers:
       - args:

--- a/manifests/daemonset.yaml
+++ b/manifests/daemonset.yaml
@@ -4,14 +4,7 @@ kind: DaemonSet
 metadata:
   name: storageos-metrics-exporter
 spec:
-  selector:
-    matchLabels:
-      app: storageos
   template:
-    metadata:
-      labels:
-        app: storageos
-        category: metrics-exporter
     spec:
       serviceAccountName: storageos-metrics-exporter
       containers:

--- a/manifests/daemonset.yaml
+++ b/manifests/daemonset.yaml
@@ -4,7 +4,15 @@ kind: DaemonSet
 metadata:
   name: storageos-metrics-exporter
 spec:
+  selector:
+    matchLabels:
+      app: storageos
+      app.kubernetes.io/component: metrics-exporter
   template:
+    metadata:
+      labels:
+        app: storageos
+        app.kubernetes.io/component: metrics-exporter
     spec:
       serviceAccountName: storageos-metrics-exporter
       containers:

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: storageos-metrics-exporter
 spec:
+  selector:
+    app: storageos
+    app.kubernetes.io/component: metrics-exporter
   ports:
   - name: metrics
     port: 9100

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -4,7 +4,8 @@ metadata:
   name: storageos-metrics-exporter
 spec:
   selector:
-    category: metrics-exporter
+    app: storageos
+    app.kubernetes.io/component: metrics-exporter
   ports:
   - name: metrics
     port: 9100

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -3,9 +3,6 @@ kind: Service
 metadata:
   name: storageos-metrics-exporter
 spec:
-  selector:
-    app: storageos
-    app.kubernetes.io/component: metrics-exporter
   ports:
   - name: metrics
     port: 9100


### PR DESCRIPTION
Remove the label "category" from the daemonset and subsequently remove it from the service.

Will also need to update the public docs example of a ServiceMonitor (https://docs.ondat.io/docs/operations/metric-exporter/) so the labels match these new ones (when we release a new operator with this change in it):
```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    app: storageos
    release: prometheus
  name: storageos-metrics
  namespace: storageos
spec:
  endpoints:
  - interval: 15s
    path: /metrics
    port: metrics
  namespaceSelector:
    matchNames:
    - storageos
  selector:
    matchLabels:
      app: storageos
      app.kubernetes.io/component: metrics-exporter
```